### PR TITLE
Added support for resolving links from resources.

### DIFF
--- a/src/main/java/no/fint/arkiv/AdditionalFieldService.java
+++ b/src/main/java/no/fint/arkiv/AdditionalFieldService.java
@@ -19,9 +19,11 @@ import java.util.stream.Stream;
 @Service
 @Slf4j
 public class AdditionalFieldService {
+    private final LinkResolver resolver;
     private final Map<String, Map<String, String>> fieldFormats;
 
-    public AdditionalFieldService(CustomFormats customFormats) {
+    public AdditionalFieldService(LinkResolver resolver, CustomFormats customFormats) {
+        this.resolver = resolver;
         this.fieldFormats = customFormats.getField();
     }
 
@@ -40,7 +42,7 @@ public class AdditionalFieldService {
             log.warn("No custom fields for {}", type);
             return Stream.empty();
         }
-        final StringSubstitutor substitutor = new StringSubstitutor(new BeanPropertyLookup<>(resource));
+        final StringSubstitutor substitutor = new StringSubstitutor(new BeanPropertyLookup<>(resolver, resource));
         return fields.entrySet().stream()
                 .map(e -> new Field(e.getKey(),
                         substitutor.replace(e.getValue())));

--- a/src/main/java/no/fint/arkiv/BeanPropertyLookup.java
+++ b/src/main/java/no/fint/arkiv/BeanPropertyLookup.java
@@ -1,24 +1,52 @@
 package no.fint.arkiv;
 
+import lombok.extern.slf4j.Slf4j;
+import no.fint.model.resource.Link;
+import org.apache.commons.beanutils.BeanIntrospector;
 import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.lookup.StringLookup;
 
+import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
 
+@Slf4j
 public class BeanPropertyLookup<T> implements StringLookup {
 
+    private final LinkResolver resolver;
     private final T bean;
 
-    public BeanPropertyLookup(T bean) {
+    public BeanPropertyLookup(LinkResolver resolver, T bean) {
+        this.resolver = resolver;
         this.bean = bean;
     }
 
     @Override
     public String lookup(String key) {
         try {
-            return String.valueOf(PropertyUtils.getProperty(bean, key));
+            return getProperty(bean, key);
         } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
     }
+
+    private String getProperty(Object target, String key) throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        log.info("Lookup {} on {}", key, target);
+        if (StringUtils.startsWith(key, "link:")) {
+            String linkProperty = StringUtils.substringBetween(key, "link:", "#");
+            String targetProperty = StringUtils.substringAfter(key, "#");
+            final Object property = PropertyUtils.getProperty(target, linkProperty);
+            if (property instanceof List && !((List<?>) property).isEmpty() && ((List<?>) property).get(0) instanceof Link) {
+                return getProperty(resolver.resolve((Link) ((List<?>) property).get(0)), targetProperty);
+            } else if (property instanceof Link) {
+                return getProperty(resolver.resolve((Link) property), targetProperty);
+            } else {
+                throw new IllegalArgumentException(linkProperty + " does not resolve to a Link");
+            }
+        }
+        return String.valueOf(PropertyUtils.getProperty(target, key));
+    }
+
 }

--- a/src/main/java/no/fint/arkiv/LinkResolver.java
+++ b/src/main/java/no/fint/arkiv/LinkResolver.java
@@ -1,0 +1,8 @@
+package no.fint.arkiv;
+
+import no.fint.model.resource.Link;
+
+public interface LinkResolver {
+    Object resolve(Link link);
+}
+

--- a/src/main/java/no/fint/arkiv/TitleService.java
+++ b/src/main/java/no/fint/arkiv/TitleService.java
@@ -18,9 +18,11 @@ import java.util.regex.Pattern;
 @Slf4j
 public class TitleService {
 
+    private final LinkResolver resolver;
     private final Map<String,String> titles;
 
-    public TitleService(CustomFormats formats) {
+    public TitleService(LinkResolver resolver, CustomFormats formats) {
+        this.resolver = resolver;
         this.titles = formats.getTitle();
     }
 
@@ -29,7 +31,7 @@ public class TitleService {
         if (!titles.containsKey(type)) {
             throw new IllegalArgumentException("No format defined for " + type);
         }
-        String title = new StringSubstitutor(new BeanPropertyLookup<>(object)).replace(titles.get(type));
+        String title = new StringSubstitutor(new BeanPropertyLookup<>(resolver, object)).replace(titles.get(type));
         log.debug("Title: '{}'", title);
         return title;
     }

--- a/src/test/groovy/no/fint/arkiv/BeansPropertiesSpec.groovy
+++ b/src/test/groovy/no/fint/arkiv/BeansPropertiesSpec.groovy
@@ -11,7 +11,7 @@ class BeansPropertiesSpec extends Specification {
         given:
         def mapper = new ObjectMapper()
         def object = mapper.readValue(getClass().getResourceAsStream('/tilskuddfartoy.json'), TilskuddFartoyResource)
-        def subst = new StringSubstitutor(new BeanPropertyLookup(object))
+        def subst = new StringSubstitutor(new BeanPropertyLookup(resolver, object))
 
         when:
         def fartoyNavn = subst.replace('${fartoyNavn}')

--- a/src/test/groovy/no/fint/arkiv/LinkResolverSpec.groovy
+++ b/src/test/groovy/no/fint/arkiv/LinkResolverSpec.groovy
@@ -1,0 +1,49 @@
+package no.fint.arkiv
+
+import no.fint.model.felles.kodeverk.Fylke
+import no.fint.model.resource.Link
+import no.fint.model.resource.felles.kodeverk.FylkeResource
+import no.fint.model.resource.felles.kodeverk.KommuneResource
+import no.fint.model.resource.felles.kompleksedatatyper.MatrikkelnummerResource
+import no.fint.model.resource.kultur.kulturminnevern.TilskuddFredaHusPrivatEieResource
+import spock.lang.Specification
+
+class LinkResolverSpec extends Specification {
+
+    def 'Test default resolution of List<Link> attributes'() {
+        given:
+        def resolver = Mock(LinkResolver)
+        def titleService = new TitleService(resolver, new CustomFormats(title: [
+                'tilskuddfredahusprivateie': '{bygningsnavn} – ${matrikkelnummer.gardsnummer}/${matrikkelnummer.bruksnummer} – {gateadresse} - Tilskudd – ${saksaar} - ${link:matrikkelnummer.kommunenummer#navn}, ${link:matrikkelnummer.kommunenummer#link:fylke#navn} – ${kulturminneId}'
+        ]))
+        def r = new TilskuddFredaHusPrivatEieResource(
+                matrikkelnummer: new MatrikkelnummerResource(
+                        gardsnummer: '1234',
+                        bruksnummer: '56'
+                ),
+                saksaar: '2020',
+                kulturminneId: '223344-5'
+        )
+        r.matrikkelnummer.addKommunenummer(Link.with('https://api.felleskomponent.no/felles/kodeverk/kommune/systemid/3005'))
+
+        when:
+        def title = titleService.getTitle(r)
+        println(title)
+
+        then:
+        noExceptionThrown()
+        2 * resolver.resolve({it.href.contains('/kommune/')}) >> new KommuneResource(
+                kode: '3005',
+                navn: 'Drammen',
+                links: [
+                        'fylke': [
+                                Link.with('https://api.felleskomponent.no/felles/kodeverk/fylke/systemid/30')
+                        ]
+                ]
+        )
+        1 * resolver.resolve({it.href.contains('/fylke/')}) >> new FylkeResource(
+                kode: '30',
+                navn: 'Viken'
+        )
+    }
+}

--- a/src/test/groovy/no/fint/arkiv/TitleServiceSpec.groovy
+++ b/src/test/groovy/no/fint/arkiv/TitleServiceSpec.groovy
@@ -8,7 +8,7 @@ class TitleServiceSpec extends Specification {
     TitleService titleService
 
     void setup() {
-        titleService = new TitleService(new CustomFormats(title: [
+        titleService = new TitleService(resolver, new CustomFormats(title: [
                 'tilskuddfartoy': '${kallesignal} - ${fartoyNavn} - Tilskudd - ${kulturminneId} - ${soknadsnummer.identifikatorverdi}'
         ]))
     }


### PR DESCRIPTION
Implements expressions of the form `${link:some.property.name#some.other.property}` where `some.property.name` should refer to `Link` or `List<Link>`. 

It then resolves the target object using a supplied `LinkResolver`, and fetches the expression `some.other.property` on the target object.

This can be done recursively, where there's a new `link:xxx#yyy` pair on the right side of `#`.